### PR TITLE
Override default 'mysql' service command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,6 +393,29 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <!-- Copy over the Docker Compose override file -->
+            <id>Copy docker-compose-override.yml</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>
+                ${project.build.directory}/${project.artifactId}-${project.version}/run/docker/
+              </outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/scripts</directory>
+                  <includes>
+                    <include>docker-compose-override.yml</include>
+                  </includes>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/readme/impl-guide.md
+++ b/readme/impl-guide.md
@@ -17,7 +17,7 @@ Build
 Run
 ```bash
 source target/go-to-scripts-dir.sh
-./start-ozone.sh
+./start-demo.sh
 ```
 
 ### Working on configurations:
@@ -40,7 +40,7 @@ Re-build:
 Then start afresh:
 ```bash
 source target/go-to-scripts-dir.sh
-./start-ozone.sh
+./start-demo.sh
 ```
 
 #### Option 2. Replace only the files needed, directly in the mounted Docker volume

--- a/scripts/docker-compose-files.txt
+++ b/scripts/docker-compose-files.txt
@@ -1,2 +1,3 @@
 docker-compose-common.yml
 docker-compose-openmrs.yml
+docker-compose-override.yml

--- a/scripts/docker-compose-override.yml
+++ b/scripts/docker-compose-override.yml
@@ -1,0 +1,4 @@
+services:
+
+  mysql:
+    command: "mysqld --character-set-server=utf8 --collation-server=utf8_general_ci --log-bin --binlog-format=ROW  --server-id=2 --sync-binlog=1 --binlog-annotate-row-events=0 --log-bin-trust-function-creators=ON"

--- a/scripts/start-ozone.sh
+++ b/scripts/start-ozone.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-source start.sh


### PR DESCRIPTION
As per [the conversation on Slack](https://openmrs.slack.com/archives/C02PYQD5D0A/p1709044537366479?thread_ts=1709043981.991739&cid=C02PYQD5D0A):
> The much larger error due to creating a custom set of function is Ozone-specific. Specifically, because we enable the binlog on the MySQL container (to support openmrs-watcher), but MySQL and MariaDB disable non-administrative users creating functions when the bin log is enabled. Basically we need to add --log-bin-trust-function-creators=ON to the MariaDB start-up command.

Here is a tentative implementation of the suggested fix.