### PR TITLE
Enable ERPNext as the default ERP

### DIFF
--- a/scripts/docker-compose-files.txt
+++ b/scripts/docker-compose-files.txt
@@ -1,3 +1,4 @@
 docker-compose-common.yml
 docker-compose-openmrs.yml
+docker-compose-erpnext.yml
 docker-compose-override.yml


### PR DESCRIPTION
This PR enables ERPNext as the default ERP.